### PR TITLE
use layer scope to detect variable reuse mode

### DIFF
--- a/sugartensor/sg_main.py
+++ b/sugartensor/sg_main.py
@@ -230,7 +230,7 @@ def sg_layer_func(func):
                 opt.name += '_%d' % (max([int(n.split('_')[-1]) for n in exist_layers]) + 1)
 
         # all layer variables start with 'lyr-' prefix
-        with tf.variable_scope(opt.name, reuse=opt.reuse):
+        with tf.variable_scope(opt.name, reuse=opt.reuse) as scope:
 
             # call layer function
             out = func(tensor, opt)
@@ -292,7 +292,7 @@ def sg_layer_func(func):
             out = tf.identity(out, 'out')
 
             # add final output summary
-            if opt.reuse is None or not opt.reuse:
+            if not scope.reuse:
                 tf.sg_summary_activation(out)
 
             # save node info for reuse
@@ -363,7 +363,7 @@ def sg_rnn_layer_func(func):
                 opt.name += '_%d' % (max([int(n.split('_')[-1]) for n in exist_layers]) + 1)
 
         # all layer variables start with 'lyr-' prefix
-        with tf.variable_scope(opt.name, reuse=opt.reuse):
+        with tf.variable_scope(opt.name, reuse=opt.reuse) as scope:
 
             # call layer function
             out = func(tensor, opt)
@@ -378,7 +378,7 @@ def sg_rnn_layer_func(func):
             out = tf.identity(out, 'out')
 
             # add final output summary
-            if opt.reuse is None or not opt.reuse:
+            if scope.reuse:
                 tf.sg_summary_activation(out)
 
             # save node info for reuse


### PR DESCRIPTION
This fixes a bug where `tf.sg_summary_activation` is called if the `variable_scope` was in reuse mode because of the parent scope and not because `reuse=True` was set.

I wanted to add a test case but I'm not sure where to put it, I put it in a gist for now (https://gist.github.com/AndreasMadsen/5eb010f998f8d1eb54d23c6c33294301).
