### PR TITLE
optional summary

### DIFF
--- a/sugartensor/sg_logging.py
+++ b/sugartensor/sg_logging.py
@@ -23,6 +23,7 @@ def sg_summary_loss(tensor, opt):
       opt:
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
       None
@@ -41,6 +42,7 @@ def sg_summary_metric(tensor, opt):
       opt:
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
       None
@@ -59,6 +61,7 @@ def sg_summary_gradient(tensor, opt):
           gradient: A 0-D `Tensor`. A gradient to log
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
         None
@@ -78,6 +81,7 @@ def sg_summary_activation(tensor, opt):
       opt:
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
       None
@@ -96,6 +100,7 @@ def sg_summary_param(tensor):
       opt:
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
       None
@@ -113,6 +118,7 @@ def sg_summary_image(tensor, opt):
       opt:
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
         None
@@ -130,6 +136,7 @@ def sg_summary_audio(tensor):
           sample_rate : An int. Sample rate to report. Default is 16000.
           prefix: A `string`. A prefix to display in the tensor board web UI.
           name: A `string`. A name to display in the tensor board web UI.
+          summary: A `boolean`. If false the summary is disabled.
 
     Returns:
         None

--- a/sugartensor/sg_logging.py
+++ b/sugartensor/sg_logging.py
@@ -14,183 +14,128 @@ __author__ = 'buriburisuri@gmail.com'
 
 
 # noinspection PyTypeChecker
-def sg_summary_loss(tensor, prefix='losses', name=None):
+@tf.sg_summary_func(prefix='losses', prettify_name=True)
+def sg_summary_loss(tensor, opt):
     r"""Register `tensor` to summary report as `loss`
 
     Args:
       tensor: A `Tensor` to log as loss
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
       None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _pretty_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        tf.summary.scalar(name, tf.reduce_mean(tensor))
-        tf.summary.histogram(name + '-h', tensor)
-    except:
-        pass
+    tf.summary.scalar(opt.name, tf.reduce_mean(tensor))
+    tf.summary.histogram(opt.name + '-h', tensor)
 
 
 # noinspection PyTypeChecker
-def sg_summary_metric(tensor, prefix='metrics', name=None):
+@tf.sg_summary_func(prefix='metrics', prettify_name=True)
+def sg_summary_metric(tensor, opt):
     r"""Register `tensor` to summary report as `metric`
 
     Args:
       tensor: A `Tensor` to log as metric
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
       None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _pretty_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        tf.summary.scalar(name, tf.reduce_mean(tensor))
-        tf.summary.histogram(name + '-h', tensor)
-    except:
-        pass
+    tf.summary.scalar(opt.name, tf.reduce_mean(tensor))
+    tf.summary.histogram(opt.name + '-h', tensor)
 
 
-def sg_summary_gradient(tensor, gradient, prefix=None, name=None):
+@tf.sg_summary_func()
+def sg_summary_gradient(tensor, opt):
     r"""Register `tensor` to summary report as `gradient`
 
     Args:
       tensor: A `Tensor` to log as gradient
-      gradient: A 0-D `Tensor`. A gradient to log
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          gradient: A 0-D `Tensor`. A gradient to log
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
         None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _full_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        tf.summary.scalar(name + '/grad', tf.reduce_mean(tf.abs(gradient)))
-        tf.summary.histogram(name + '/grad-h', tf.abs(gradient))
-    except:
-        pass
+    assert opt.gradient is not None, 'gradient is mandatory.'
+
+    tf.summary.scalar(opt.name + '/grad', tf.reduce_mean(tf.abs(opt.gradient)))
+    tf.summary.histogram(opt.name + '/grad-h', tf.abs(opt.gradient))
 
 
-def sg_summary_activation(tensor, prefix=None, name=None):
+@tf.sg_summary_func()
+def sg_summary_activation(tensor, opt):
     r"""Register `tensor` to summary report as `activation`
 
     Args:
       tensor: A `Tensor` to log as activation
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
       None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _pretty_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        tf.summary.scalar(name + '/ratio',
-                          tf.reduce_mean(tf.cast(tf.greater(tensor, 0), tf.sg_floatx)))
-        tf.summary.histogram(name + '/ratio-h', tensor)
-    except:
-        pass
+    tf.summary.scalar(opt.name + '/ratio',
+                      tf.reduce_mean(tf.cast(tf.greater(tensor, 0), tf.sg_floatx)))
+    tf.summary.histogram(opt.name + '/ratio-h', tensor)
 
 
-def sg_summary_param(tensor, prefix=None, name=None):
+@tf.sg_summary_func()
+def sg_summary_param(tensor):
     r"""Register `tensor` to summary report as `parameters`
 
     Args:
       tensor: A `Tensor` to log as parameters
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
       None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _pretty_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        norm = tensor
-        tf.summary.scalar(name + '/abs', tf.reduce_mean(tf.abs(tensor)))
-        tf.summary.histogram(name + '/abs-h', tf.abs(tensor))
-    except:
-        pass
+    tf.summary.scalar(opt.name + '/abs', tf.reduce_mean(tf.abs(tensor)))
+    tf.summary.histogram(opt.name + '/abs-h', tf.abs(tensor))
 
 
-def sg_summary_image(tensor, prefix=None, name=None):
+@tf.sg_summary_func()
+def sg_summary_image(tensor, opt):
     r"""Register `tensor` to summary report as `image`
 
     Args:
       tensor: A tensor to log as image
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
         None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _full_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        tf.summary.image(name + '-im', tensor)
-    except:
-        pass
+    tf.summary.image(opt.name + '-im', tensor)
 
 
-def sg_summary_audio(tensor, sample_rate=16000, prefix=None, name=None):
+@tf.sg_summary_func()
+def sg_summary_audio(tensor):
     r"""Register `tensor` to summary report as audio
 
     Args:
       tensor: A `Tensor` to log as audio
-      sample_rate : An int. Sample rate to report. Default is 16000.
-      prefix: A `string`. A prefix to display in the tensor board web UI.
-      name: A `string`. A name to display in the tensor board web UI.
+      opt:
+          sample_rate : An int. Sample rate to report. Default is 16000.
+          prefix: A `string`. A prefix to display in the tensor board web UI.
+          name: A `string`. A name to display in the tensor board web UI.
 
     Returns:
         None
     """
-    # defaults
-    prefix = '' if prefix is None else prefix + '/'
-    # summary name
-    name = prefix + _full_name(tensor) if name is None else prefix + name
-    # summary statistics
-    # noinspection PyBroadException
-    try:
-        tf.summary.audio(name + '-au', tensor, sample_rate)
-    except:
-        pass
-
-
-def _pretty_name(tensor):
-    return ''.join(tensor.name.split(':')[:-1]).split('/')[-1]
-
-
-def _full_name(tensor):
-    return ''.join(tensor.name.split(':')[:-1])
+    opt += tf.sg_opt(sample_rate=16000)
+    tf.summary.audio(opt.name + '-au', tensor, opt.sample_rate)
 
 
 #

--- a/sugartensor/sg_main.py
+++ b/sugartensor/sg_main.py
@@ -156,6 +156,7 @@ def sg_summary_func(prefix='', prettify_name=False):
               kwargs:
                   prefix: A `string`. A prefix to display in the tensor board web UI.
                   name: A `string`. A name to display in the tensor board web UI.
+                  summary: A `boolean`. If false the summary is disabled.
             """
             full_name = ''.join(tensor.name.split(':')[:-1])
             pretty_name = ''.join(tensor.name.split(':')[:-1]).split('/')[-1]
@@ -163,7 +164,8 @@ def sg_summary_func(prefix='', prettify_name=False):
             # kwargs parsing
             opt = tf.sg_opt(kwargs) + _context + tf.sg_opt(
                 prefix=prefix,
-                name=pretty_name if prettify_name else full_name
+                name=pretty_name if prettify_name else full_name,
+                summary=True
             )
 
             if opt.prefix != '':
@@ -171,7 +173,8 @@ def sg_summary_func(prefix='', prettify_name=False):
 
             # noinspection PyBroadException
             try:
-                func(tensor, opt)
+                if opt.summary:
+                    func(tensor, opt)
             except:
                 pass
 

--- a/sugartensor/sg_main.py
+++ b/sugartensor/sg_main.py
@@ -93,7 +93,7 @@ def sg_context(**kwargs):
 
     For example, in the following example, the default value of parameter `bn` will be set to True
     in the all layers within the with block.
-    
+
     ```
     with tf.sg_context(bn=True):
         ...
@@ -131,11 +131,60 @@ def sg_context(**kwargs):
 
 
 #
+# summary function annotator
+#
+def sg_summary_func(prefix='', prettify_name=False):
+    r"""Decorates a function `func` so that it can be a summary function.
+
+    Args:
+        prefix: A `string`. A prefix to display in the tensor board web UI.
+        pretty_name: A `boolean`. Should the default name be prettified.
+        func: function to decorate
+
+    Returns:
+      A summary function.
+
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(tensor, **kwargs):
+            r"""Manages input and call to summary function.
+
+            Args:
+              tensor: A `Tensor` to log as loss
+              kwargs:
+                  prefix: A `string`. A prefix to display in the tensor board web UI.
+                  name: A `string`. A name to display in the tensor board web UI.
+            """
+            full_name = ''.join(tensor.name.split(':')[:-1])
+            pretty_name = ''.join(tensor.name.split(':')[:-1]).split('/')[-1]
+
+            # kwargs parsing
+            opt = tf.sg_opt(kwargs) + _context + tf.sg_opt(
+                prefix=prefix,
+                name=pretty_name if prettify_name else full_name
+            )
+
+            if opt.prefix != '':
+                opt.name = opt.prefix + '/' + opt.name
+
+            # noinspection PyBroadException
+            try:
+                func(tensor, opt)
+            except:
+                pass
+
+        return wrapper
+
+    return decorator
+
+#
 # sugar function annotator
 #
 
 def sg_sugar_func(func):
-    r""" Decorates a function `func` so that it can be a sugar function. 
+    r""" Decorates a function `func` so that it can be a sugar function.
     Sugar function can be used in a chainable manner.
 
     Args:
@@ -172,7 +221,7 @@ def sg_layer_func(func):
     @wraps(func)
     def wrapper(tensor, **kwargs):
         r"""Manages arguments of `tf.sg_opt`.
-        
+
         Args:
           tensor: A `tensor` (automatically passed by decorator).
           kwargs:
@@ -182,10 +231,10 @@ def sg_layer_func(func):
             bn: Boolean. If True, batch normalization is applied.
             ln: Boolean. If True, layer normalization is applied.
             dout: A float of range [0, 100). A dropout rate. Set to 0 by default.
-            bias: Boolean. If True, biases are added. As a default, it is set to True 
+            bias: Boolean. If True, biases are added. As a default, it is set to True
             name: A name for the layer. As a default, the function name is assigned.
             act: A name of activation function. e.g., `sigmoid`, `tanh`, etc.
-            reuse: `True` or `None`; if `True`, we go into reuse mode for this `layer` scope 
+            reuse: `True` or `None`; if `True`, we go into reuse mode for this `layer` scope
               as well as all sub-scopes; if `None`, we just inherit the parent scope reuse.
         """
 
@@ -394,7 +443,7 @@ def sg_rnn_layer_func(func):
 
 # noinspection PyProtectedMember
 def sg_reuse(tensor, **opt):
-    r""" Reconstruct computational graph of `tensor` so all the parameters 
+    r""" Reconstruct computational graph of `tensor` so all the parameters
     can be reused and replace its input tensor with `opt.input`.
 
     Args:
@@ -559,12 +608,12 @@ def sg_arg_def(**kwargs):
     Returns:
       None
 
-    For example, 
-    
+    For example,
+
     ```
     # Either of the following two lines will define `--n_epoch` command line argument and set its default value as 1.
-    
-    tf.sg_arg_def(n_epoch=1) 
+
+    tf.sg_arg_def(n_epoch=1)
     tf.sg_arg_def(n_epoch=(1, 'total number of epochs'))
     ```
     """

--- a/sugartensor/sg_train.py
+++ b/sugartensor/sg_train.py
@@ -35,9 +35,9 @@ def sg_train(**kwargs):
           Otherwise (Default), the value of the stored `_learning_rate` is taken.
         save_dir: A string. The root path to which checkpoint and log files are saved.
           Default is `asset/train`.
-        max_ep: A positive integer. Maximum number of epochs. Default is 1000.    
-        ep_size: A positive integer. Number of Total batches in an epoch. 
-          For proper display of log. Default is 1e5.    
+        max_ep: A positive integer. Maximum number of epochs. Default is 1000.
+        ep_size: A positive integer. Number of Total batches in an epoch.
+          For proper display of log. Default is 1e5.
 
         save_interval: A Python scalar. The interval of saving checkpoint files.
           By default, for every 600 seconds, a checkpoint file is written.
@@ -49,7 +49,7 @@ def sg_train(**kwargs):
         category: Scope name or list to train
 
         tqdm: Boolean. If True (Default), progress bars are shown.
-        console_log: Boolean. If True, a series of loss will be shown 
+        console_log: Boolean. If True, a series of loss will be shown
           on the console instead of tensorboard. Default is False.
     """
     opt = tf.sg_opt(kwargs)
@@ -74,9 +74,9 @@ def sg_train(**kwargs):
 
 def sg_init(sess):
     r""" Initializes session variables.
-    
+
     Args:
-      sess: Session to initialize. 
+      sess: Session to initialize.
     """
     # initialize variables
     sess.run(tf.group(tf.global_variables_initializer(),
@@ -86,15 +86,15 @@ def sg_init(sess):
 def sg_print(tensor_list):
     r"""Simple tensor printing function for debugging.
     Prints the value, shape, and data type of each tensor in the list.
-    
+
     Args:
       tensor_list: A list/tuple of tensors or a single tensor.
-      
+
     Returns:
       The value of the tensors.
-      
+
     For example,
-    
+
     ```python
     import sugartensor as tf
     a = tf.constant([1.])
@@ -104,7 +104,7 @@ def sg_print(tensor_list):
     #              [ 2.] (1,) float32
     print(out)
     # Should print [array([ 1.], dtype=float32), array([ 2.], dtype=float32)]
-    ``` 
+    ```
     """
     # to list
     if type(tensor_list) is not list and type(tensor_list) is not tuple:
@@ -199,7 +199,7 @@ def sg_optim(loss, **kwargs):
         # exclude batch normal statics
         if 'mean' not in v.name and 'variance' not in v.name \
                 and 'beta' not in v.name and 'gamma' not in v.name:
-            tf.sg_summary_gradient(v, g)
+            tf.sg_summary_gradient(v, gradient=g)
 
     # gradient update op
     grad_op = optim.apply_gradients(gradient, global_step=tf.sg_global_step())
@@ -217,7 +217,7 @@ def sg_optim(loss, **kwargs):
 
 def sg_train_func(func):
     r""" Decorates a function `func` as sg_train_func.
-    
+
     Args:
         func: A function to decorate
     """
@@ -228,7 +228,7 @@ def sg_train_func(func):
         Args:
           **kwargs:
             lr: A Python Scalar (optional). Learning rate. Default is .001.
-    
+
             eval_metric: A list of tensors containing the value to evaluate. Default is [].
             early_stop: Boolean. If True (default), the training should stop when the following two conditions are met.
               i. Current loss is less than .95 * previous loss.
@@ -237,19 +237,19 @@ def sg_train_func(func):
               Otherwise (Default), the value of the stored `_learning_rate` is taken.
             save_dir: A string. The root path to which checkpoint and log files are saved.
               Default is `asset/train`.
-            max_ep: A positive integer. Maximum number of epochs. Default is 1000.    
-            ep_size: A positive integer. Number of Total batches in an epoch. 
-              For proper display of log. Default is 1e5.    
-    
+            max_ep: A positive integer. Maximum number of epochs. Default is 1000.
+            ep_size: A positive integer. Number of Total batches in an epoch.
+              For proper display of log. Default is 1e5.
+
             save_interval: A Python scalar. The interval of saving checkpoint files.
               By default, for every 600 seconds, a checkpoint file is written.
             log_interval: A Python scalar. The interval of recoding logs.
               By default, for every 60 seconds, logging is executed.
             max_keep: A positive integer. Maximum number of recent checkpoints to keep. Default is 5.
             keep_interval: A Python scalar. How often to keep checkpoints. Default is 1 hour.
-    
+
             tqdm: Boolean. If True (Default), progress bars are shown.
-            console_log: Boolean. If True, a series of loss will be shown 
+            console_log: Boolean. If True, a series of loss will be shown
               on the console instead of tensorboard. Default is False.
         """
         opt = tf.sg_opt(kwargs)


### PR DESCRIPTION
This makes it possible to disable summaries in a `sg_context` scope using `with sg_context(summary=False)`.

The motivation for this is that I otherwise end up having 1000+ summaries, it takes a long time load in `tensorboard` and I can't open the taps anyway as the browser will just freeze.

---

In order to implement this, a `sg_summary_func` decorator similar to `sg_sugar_func` and `sg_layer_func` was added. This decorator simplifies the summary implementations quite a lot and allows `sg_context` to affect the summary functions.

Unfortunately, this introduces a two small API change.
* if `prefix=None` is set the default prefix now is used, where it before removed the prefix. To remove the prefix `prefix=''` should now be used. I hope this is okay, to my mind it actually makes more sense.
* The required `gradient` argument in `sg_summary_gradient` must now be provided as a keyword argument. This is similar to `sg_ce` and the other loss functions.